### PR TITLE
Implement manual activation on iOS

### DIFF
--- a/ios/RNGestureHandler.h
+++ b/ios/RNGestureHandler.h
@@ -59,7 +59,8 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
 @property (nonatomic, readonly, nullable) UIGestureRecognizer *recognizer;
 @property (nonatomic) BOOL enabled;
 @property (nonatomic) BOOL usesDeviceEvents;
-@property(nonatomic) BOOL shouldCancelWhenOutside;
+@property (nonatomic) BOOL shouldCancelWhenOutside;
+@property (nonatomic) BOOL requireManualActivation;
 
 - (void)bindToView:(nonnull UIView *)view;
 - (void)unbindFromView;
@@ -70,6 +71,8 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
 - (RNGestureHandlerState)state;
 - (nullable RNGestureHandlerEventExtraData *)eventExtraData:(nonnull id)recognizer;
 
+- (void)stopActivationBlocker;
+- (void)resetManualActivation;
 - (void)reset;
 - (void)sendEventsInState:(RNGestureHandlerState)state
            forViewWithTag:(nonnull NSNumber *)reactTag

--- a/ios/RNGestureHandler.h
+++ b/ios/RNGestureHandler.h
@@ -60,7 +60,7 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
 @property (nonatomic) BOOL enabled;
 @property (nonatomic) BOOL usesDeviceEvents;
 @property (nonatomic) BOOL shouldCancelWhenOutside;
-@property (nonatomic) BOOL requireManualActivation;
+@property (nonatomic) BOOL manualActivation;
 
 - (void)bindToView:(nonnull UIView *)view;
 - (void)unbindFromView;

--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -95,7 +95,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   _simultaneousHandlers = nil;
   _hitSlop = RNGHHitSlopEmpty;
   
-  [self resetManualActivation];
+  self.manualActivation = NO;
 }
 
 - (void)configure:(NSDictionary *)config
@@ -116,11 +116,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   
     prop = config[@"manualActivation"];
       if (prop != nil) {
-        if ([RCTConvert BOOL:prop]) {
-            [self setManualActivation];
-        } else {
-            [self resetManualActivation];
-        }
+        self.manualActivation = [RCTConvert BOOL:prop];
     }
 
     prop = config[@"hitSlop"];
@@ -263,20 +259,17 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   }
 }
 
-- (void)setManualActivation
+- (void)setManualActivation:(BOOL)manualActivation
 {
-  _requireManualActivation = YES;
-  _manualActivationRecognizer = [[RNManualActivationRecognizer alloc] initWithGestureHandler:self];
+  _manualActivation = manualActivation;
+  
+  if (manualActivation) {
+    _manualActivationRecognizer = [[RNManualActivationRecognizer alloc] initWithGestureHandler:self];
 
-  if (_recognizer.view != nil) {
-    [_recognizer.view addGestureRecognizer:_manualActivationRecognizer];
-  }
-}
-
-- (void)resetManualActivation
-{
-  _requireManualActivation = NO;
-  if (_manualActivationRecognizer != nil) {
+    if (_recognizer.view != nil) {
+      [_recognizer.view addGestureRecognizer:_manualActivationRecognizer];
+    }
+  } else if (_manualActivationRecognizer != nil) {
     [_manualActivationRecognizer.view removeGestureRecognizer:_manualActivationRecognizer];
     _manualActivationRecognizer = nil;
   }

--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -1,4 +1,5 @@
 #import "RNGestureHandler.h"
+#import "RNManualActivationRecognizer.h"
 
 #import "Handlers/RNNativeViewHandler.h"
 
@@ -61,6 +62,7 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
 static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
 @implementation RNGestureHandler {
+    RNManualActivationRecognizer *_manualActivationRecognizer;
     NSArray<NSNumber *> *_handlersToWaitFor;
     NSArray<NSNumber *> *_simultaneousHandlers;
     RNGHHitSlop _hitSlop;
@@ -73,6 +75,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
         _tag = tag;
         _lastState = RNGestureHandlerStateUndetermined;
         _hitSlop = RNGHHitSlopEmpty;
+        _manualActivationRecognizer = nil;
 
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
@@ -91,6 +94,8 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   _handlersToWaitFor = nil;
   _simultaneousHandlers = nil;
   _hitSlop = RNGHHitSlopEmpty;
+  
+  [self resetManualActivation];
 }
 
 - (void)configure:(NSDictionary *)config
@@ -107,6 +112,15 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
     prop = config[@"shouldCancelWhenOutside"];
     if (prop != nil) {
         _shouldCancelWhenOutside = [RCTConvert BOOL:prop];
+    }
+  
+    prop = config[@"manualActivation"];
+      if (prop != nil) {
+        if ([RCTConvert BOOL:prop]) {
+            [self setManualActivation];
+        } else {
+            [self resetManualActivation];
+        }
     }
 
     prop = config[@"hitSlop"];
@@ -147,12 +161,16 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
     view.userInteractionEnabled = YES;
     self.recognizer.delegate = self;
     [view addGestureRecognizer:self.recognizer];
+  
+  [self bindManualActivationToView:view];
 }
 
 - (void)unbindFromView
 {
     [self.recognizer.view removeGestureRecognizer:self.recognizer];
     self.recognizer.delegate = nil;
+  
+    [self unbindManualActivation];
 }
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(UIGestureRecognizer *)recognizer
@@ -234,6 +252,48 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
             return RNGestureHandlerStateActive;
     }
     return RNGestureHandlerStateUndetermined;
+}
+
+#pragma mark Manual activation
+
+- (void)stopActivationBlocker
+{
+  if (_manualActivationRecognizer != nil) {
+    [_manualActivationRecognizer fail];
+  }
+}
+
+- (void)setManualActivation
+{
+  _requireManualActivation = YES;
+  _manualActivationRecognizer = [[RNManualActivationRecognizer alloc] initWithGestureHandler:self];
+
+  if (_recognizer.view != nil) {
+    [_recognizer.view addGestureRecognizer:_manualActivationRecognizer];
+  }
+}
+
+- (void)resetManualActivation
+{
+  _requireManualActivation = NO;
+  if (_manualActivationRecognizer != nil) {
+    [_manualActivationRecognizer.view removeGestureRecognizer:_manualActivationRecognizer];
+    _manualActivationRecognizer = nil;
+  }
+}
+
+- (void)bindManualActivationToView:(UIView *)view
+{
+  if (_manualActivationRecognizer != nil) {
+    [view addGestureRecognizer:_manualActivationRecognizer];
+  }
+}
+
+- (void)unbindManualActivation
+{
+  if (_manualActivationRecognizer != nil) {
+    [_manualActivationRecognizer.view removeGestureRecognizer:_manualActivationRecognizer];
+  }
 }
 
 #pragma mark UIGestureRecognizerDelegate

--- a/ios/RNGestureHandlerModule.m
+++ b/ios/RNGestureHandlerModule.m
@@ -154,11 +154,19 @@ RCT_EXPORT_METHOD(handleClearJSResponder)
     } else if (state == 3) { // CANCELLED
       handler.recognizer.state = UIGestureRecognizerStateCancelled;
     } else if (state == 4) { // ACTIVE
+      [handler stopActivationBlocker];
       handler.recognizer.state = UIGestureRecognizerStateBegan;
     } else if (state == 5) { // ENDED
       handler.recognizer.state = UIGestureRecognizerStateEnded;
     }
   }
+  
+  // the code needs to be uncommented after merging relevant PRs, I left it
+  // here not to forget about it later
+  // if the gesture was set to finish, cancel all pointers it was tracking
+//  if (state == 1 || state == 3 || state == 5) {
+//    [handler.pointerTracker cancelPointers];
+//  }
   
   // do not send state change event when activating because it bypasses
   // shouldRequireFailureOfGestureRecognizer

--- a/ios/RNManualActivationRecognizer.h
+++ b/ios/RNManualActivationRecognizer.h
@@ -1,0 +1,10 @@
+#import <UIKit/UIGestureRecognizerSubclass.h>
+
+@class RNGestureHandler;
+
+@interface RNManualActivationRecognizer : UIGestureRecognizer <UIGestureRecognizerDelegate>
+
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler;
+- (void)fail;
+
+@end

--- a/ios/RNManualActivationRecognizer.m
+++ b/ios/RNManualActivationRecognizer.m
@@ -1,0 +1,80 @@
+#import "RNManualActivationRecognizer.h"
+#import "RNGestureHandler.h"
+
+@implementation RNManualActivationRecognizer {
+  RNGestureHandler *_handler;
+  int _activePointers;
+}
+
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler
+{
+  if ((self = [super initWithTarget:self action:nil])) {
+    _handler = gestureHandler;
+    self.delegate = self;
+    _activePointers = 0;
+  }
+  return self;
+}
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [super touchesBegan:touches withEvent:event];
+
+  _activePointers += touches.count;
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [super touchesMoved:touches withEvent:event];
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [super touchesEnded:touches withEvent:event];
+  
+  _activePointers -= touches.count;
+  
+  if (_activePointers == 0) {
+    [self fail];
+    [self reset];
+  }
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [super touchesCancelled:touches withEvent:event];
+  
+  _activePointers = 0;
+  [self reset];
+}
+
+- (void)reset
+{
+  self.enabled = YES;
+  [super reset];
+}
+
+- (void)fail
+{
+  self.enabled = NO;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  return YES;
+}
+
+- (BOOL)shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
+  if (handler != nil) {
+    if (handler.tag == _handler.tag) {
+      return YES;
+    }
+  }
+  
+  return NO;
+}
+
+@end


### PR DESCRIPTION
## Description

Implementation of manual activation on iOS.
In order to do this I added a 'dummy' `UIGestureRecognizer` that can be recognized simultaneously with all other recognizers, but the original gesture needs to wait for a failure of it. When user tries to activate the handler, the dummy recognizer fails, allowing the gesture to activate.
The dummy recognizer is initialized only when `manualActivation` is set to `true`. 

## Test plan

Needs to be tested when all parts are merged together.
